### PR TITLE
Fix typo in main_search_synth error message

### DIFF
--- a/main_search_synth.py
+++ b/main_search_synth.py
@@ -123,7 +123,7 @@ def generate_one_sample(predicate_GDL,
         return (True, None)
     
     except Exception as e:
-        print(f"===== Error Occured: {fig_idx} =====")
+        print(f"===== Error Occurred: {fig_idx} =====")
         tb = traceback.format_exc()
         # print(tb)
         task_info = {


### PR DESCRIPTION
## Summary
- correct misspelled 'Occured' to 'Occurred' in error log message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aea6c2e4508331a8fc4c0c7c9d3329